### PR TITLE
Add easiest error handling

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -11,6 +11,8 @@ export uuid = (name) ->
     return badRequest("Invalid format for the name '#{name}'")
   unless id = await NAMES.get(name.toLowerCase(), "text")
     unless response = await usernameToUuid(name)
+      if response == false 
+        return badGateway()
       return notFound("No user with the name '#{name}' was found")
     id = response.id?.asUuid(dashed: true)
     await NAMES.put(name.toLowerCase(), id, {expirationTtl: 60 * 5})

--- a/src/http.coffee
+++ b/src/http.coffee
@@ -34,7 +34,10 @@ export request = (url, {method, type, body, ttl, parser} = {}) ->
     if response.ok && response.status < 204
       response = await parser(response)
     else
-      response = null
+      if response.status != 204 && !response.ok
+        response = false
+      else
+        response = null // Null means No content 
   response
 
 # Send a Http request and get a Json response.
@@ -131,3 +134,10 @@ export notFound = (reason = null) ->
 # @see #error(code, message, reason)
 export tooManyRequests = (reason = null) ->
   error(reason, code: 429, type: "Too Many Requests")
+
+
+# Respond with a 502 - Bad Gateway error.
+#
+# @see #error(code, message, reason)
+export badGateway = (reason = null) ->
+  error(reason, code: 502, type: "Bad Gateway")


### PR DESCRIPTION
That is easiest fix for issue - https://github.com/Electroid/mojang-api/issues/35 Its not perfect but it works and makes some sense at certain point.

But to be clear much easier would be not writing useless helpers for HTTP that are changing structure of error handling atm you are not able to check inside of API function from which reason mojang failed and giving positive information (account not found when it is not true is really dangerous for potential users of this API). That's why I provided simple error handling that introduces in response third state - false if response is set to false that means that it failed. response that is null is reasonable when there is no content provided by external API (mojang) but when mojang responds with error (like when it's down) we set response to false to give substitute for proper error handling.

So my recommendation is to accept this PR and in free time work on removing all of these HTTP method (because it just wrapping old & good fetch API) and just rewire your methods to use it proper


```coffescript
export usernameToUuid = (username, secs = -1) -> 
  time = if secs >= 0 then "?at=#{secs}" else ""
  response = await fetch("https://api.mojang.com/users/profiles/minecraft/#{username}#{time}")
  
  if response.ok
     result =  await response.json()
     return {success:true,status: response.status,result }
 else 
     return {success:false, status: response.status, result: null}
 
  {success, status, result } = unless response = await usernameToUuid(name) 
``` 

I just provided fast draft how I would see it working. That change would improve error handling and reduce amounts of code o maintain leaving everything for fetch API. 