### PR TITLE
Add profile actions to response

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Username or UUID -> Everything<br>
   },
   "legacy": <true|null>,
   "demo": <true|null>,
+  "profile_actions": [
+    <zero or more of "FORCED_NAME_CHANGE" or "USING_BANNED_SKIN">
+  ],
   "created_at": <date|null>
 }
 ```
@@ -77,6 +80,9 @@ UUID -> Profile + Textures<br>
       "name": "textures",
       "value": <base64> // Then decode the base64 string and make http requests to fetch the textures...
     }
+  ],
+  "profile_actions": [
+    <zero or more of "FORCED_NAME_CHANGE" or "USING_BANNED_SKIN">
   ]
 }
 ```

--- a/src/api.coffee
+++ b/src/api.coffee
@@ -65,6 +65,7 @@ export user = (id) ->
       raw: {value: texturesRaw.value, signature: texturesRaw.signature} unless texturesRaw.isEmpty()
     legacy: true if profile.legacy
     demo: true if profile.demo
+    profile_actions: profile.profileActions ? []
     created_at: date
   await USERS.put(id, JSON.stringify(response), {expirationTtl: 3600})
   respond(response, json: true)


### PR DESCRIPTION
Minecraft 1.20.2 adds username and skin reports, and banned players can be forced to change their name/skin before they can play multiplayer again. This information was added to the UUID -> Profile + Textures endpoint:

```json
"profileActions": [
  "FORCED_NAME_CHANGE",
  "USING_BANNED_SKIN"
]
```

(The names of the profile actions were found through code decompilation)

The endpoint already returns `profileActions: []` for all accounts ([example](https://sessionserver.mojang.com/session/minecraft/profile/f6489b797a9f49e2980e265a05dbc3af)).